### PR TITLE
feat: add October CMS v4 compatibility

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -3,7 +3,6 @@
 namespace JanVince\SmallContactForm;
 
 use Backend;
-use Validator;
 use JanVince\SmallContactForm\Models\Settings;
 use JanVince\SmallContactForm\Rules\CustomNotRegexRule;
 use JanVince\SmallContactForm\Classes\UnreadRecords;
@@ -36,20 +35,7 @@ class Plugin extends PluginBase {
      * @return void
      */
     public function register() {
-        if (class_exists(\System::class) && version_compare(\System::VERSION, '3.0.0', '>=')) {
-            $this->registerValidationRule('custom_not_regex', CustomNotRegexRule::class);
-        }
-    }
-
-    /**
-     * Boot Plugin Hook
-     *
-     * @return void
-     */
-    public function boot() {
-        if (!class_exists(\System::class) || (class_exists(\System::class) && version_compare(\System::VERSION, '3.0.0', '<'))) {
-            Validator::extend('custom_not_regex', CustomNotRegexRule::class);
-        }
+        $this->registerValidationRule('custom_not_regex', CustomNotRegexRule::class);
     }
 
     public function registerSettings() {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Small Contact form
 > Simple but flexible contact form builder with custom fields, validation and passive antispam.
+>
+> Compatible with October CMS v4.
 
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,14 @@
     "issues": "https://github.com/jan-vince/smallcontactform/issues"
   },
   "require": {
-    "php": ">=7.0",
-    "composer/installers": "~1.0",
-    "google/recaptcha": "^1.2@dev"
+    "php": ">=8.0",
+    "composer/installers": "^2.0",
+    "google/recaptcha": "^1.2"
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "stable",
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true
+    }
+  }
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -333,3 +333,5 @@
     - scf_tables_07.php
 1.69.1:
     - Fixed reCaptcha invisible script for multiple forms
+1.70.0:
+    - Updated for October CMS v4 compatibility


### PR DESCRIPTION
## Summary
- simplify validation rule registration for October CMS v4
- document October v4 compatibility
- require PHP 8 and stable dependencies

## Testing
- `php -l Plugin.php`
- `php -l rules/CustomNotRegexRule.php`
- `composer validate` *(fails: lock file is not up to date; network error prevented `composer update`)*

------
https://chatgpt.com/codex/tasks/task_e_688f70745ebc832ba673526a734aef06